### PR TITLE
WebRequests read as Encoding.ASCII instead of Encoding UTF8

### DIFF
--- a/TwitchLib/TwitchAPI.cs
+++ b/TwitchLib/TwitchAPI.cs
@@ -385,7 +385,7 @@ namespace TwitchLib
 
             using (var responseStream = await request.GetResponseAsync())
             {
-                return await new StreamReader(responseStream.GetResponseStream(), Encoding.ASCII).ReadToEndAsync();
+                return await new StreamReader(responseStream.GetResponseStream(), Encoding.UTF8).ReadToEndAsync();
             }
         }
 
@@ -410,7 +410,7 @@ namespace TwitchLib
 
             using (var responseStream = await request.GetResponseAsync())
             {
-                return await new StreamReader(responseStream.GetResponseStream(), Encoding.ASCII).ReadToEndAsync();
+                return await new StreamReader(responseStream.GetResponseStream(), Encoding.UTF8).ReadToEndAsync();
             }
         }
     }


### PR DESCRIPTION
MakeGetRequest in TwitchApi class returns response streams as Encoding.ASCII when it should be Encoding.UTF8