### PR TITLE
Fixed Timeout duration

### DIFF
--- a/TwitchLib/TwitchClient.cs
+++ b/TwitchLib/TwitchClient.cs
@@ -518,7 +518,7 @@ namespace TwitchLib
         /// <param name="dryRun">Indicates a dryrun (will not sened if true)</param>
         public void TimeoutUser(JoinedChannel channel, string viewer, TimeSpan duration, string message = "", bool dryRun = false)
         {
-            SendMessage(channel, $".timeout {viewer} {duration.Seconds} {message}", dryRun);
+            SendMessage(channel, $".timeout {viewer} {duration.TotalSeconds} {message}", dryRun);
         }
 
         /// <summary>


### PR DESCRIPTION
duration.seconds was returning 0 if the time was a multiple of 60.
For example a timeout with a duration of 600 Seconds would result in a time of 0 seconds.