### PR TITLE
Clear JoinedChannels at Disconnected event.

### DIFF
--- a/TwitchLib/TwitchClient.cs
+++ b/TwitchLib/TwitchClient.cs
@@ -584,6 +584,7 @@ namespace TwitchLib
         private void Disconnected(object sender, EventArgs e)
         {
             OnDisconnected?.Invoke(this, new OnDisconnectedArgs { Username = TwitchUsername });
+            JoinedChannels.Clear();
         }
 
         private void ConnectionError(object sender, EventArgs e)


### PR DESCRIPTION
If the TCP connection is silently cut the client thinks it is still listening to these channels.
I don't know whether it should fire "OnClientLeftChannel" or not.
OnClientLeftChannel fires only when a client _successfully_ leaves a channel.