### PR TITLE
Adds sync/async GetAllChannelSubscribers

### DIFF
--- a/TwitchLib/Internal/TwitchAPI.cs
+++ b/TwitchLib/Internal/TwitchAPI.cs
@@ -335,6 +335,24 @@ namespace TwitchLib.Internal
             return int.Parse(json.SelectToken("_total").ToString());
         }
 
+        public static async Task<ChannelSubscribersResponse> GetAllChannelSubscribers(string channel, string accessToken = null)
+        {
+            var csr = new ChannelSubscribersResponse();
+            var totalSubscribers = await GetSubscriberCount(channel, accessToken);
+            int offset = 0;
+            int pageCount = (totalSubscribers + 90 - 1) / 90;
+            for (int i = 1; i < pageCount; i++)
+            {
+                var args = $"?limit=90&offset={offset}";
+                var resp = await MakeGetRequest($"https://api.twitch.tv/kraken/channels/{channel}/subscriptions{args}", accessToken);
+                JObject json = JObject.Parse(resp);
+                foreach (JToken subscription in json.SelectToken("subscriptions"))
+                    csr.Subscribers.Add(new Subscription(subscription.ToString()));
+                offset += 90;
+            }
+            return csr;
+        }
+
         public static async Task<ChannelHasUserSubscribedResponse> ChannelHasUserSubscribed(string username, string channel, string accessToken = null)
         {
             try

--- a/TwitchLib/Models/API/ChannelSubscribersResponse.cs
+++ b/TwitchLib/Models/API/ChannelSubscribersResponse.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+
+namespace TwitchLib.Models.API
+{
+    /// <summary>Class representing response from Twitch API for channel Subscribers.</summary>
+    public class ChannelSubscribersResponse
+    {
+        /// <summary>Property representing list of Subscriber objects.</summary>
+        public List<Subscription> Subscribers { get; protected set; } = new List<Subscription>();
+        /// <summary>Property representing total subscriber count.</summary>
+        public int TotalSubscriberCount { get { return Subscribers.Count; } }
+        /// <summary>Property representing cursor for pagination.</summary>
+    }
+}

--- a/TwitchLib/Models/API/Subscription.cs
+++ b/TwitchLib/Models/API/Subscription.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Newtonsoft.Json.Linq;
+
+namespace TwitchLib.Models.API
+{
+    /// <summary>Class representing a channel subscription as fetched via Twitch API</summary>
+    public class Subscription
+    {
+        /// <summary>DateTime object representing when a subscription was created.</summary>
+        public DateTime CreatedAt { get; protected set; }
+        /// <summary>TimeSpan object representing the amount of time since the subscription was created.</summary>
+        public TimeSpan TimeSinceCreated { get; protected set; }
+        /// <summary>User details returned along with the request.</summary>
+        public User User { get; protected set; }
+
+        /// <summary>Constructor for Subscription</summary>
+        public Subscription(string apiResponse)
+        {
+            JObject json = JObject.Parse(apiResponse);
+            CreatedAt = Convert.ToDateTime(json.SelectToken("created_at").ToString());
+            TimeSinceCreated = DateTime.UtcNow - CreatedAt;
+            User = new User(json.SelectToken("user").ToString());
+        }
+    }
+}

--- a/TwitchLib/TwitchAPI.cs
+++ b/TwitchLib/TwitchAPI.cs
@@ -686,6 +686,23 @@ namespace TwitchLib
             /// <param name="accessToken">An oauth token with the required scope.</param>
             /// <returns>True if the user is subscribed to the channel, false otherwise.</returns>
             public static async Task<ChannelHasUserSubscribedResponse> ChannelHasUserSubscribedAsync(string username, string channel, string accessToken = null) => await Internal.TwitchApi.ChannelHasUserSubscribed(username, channel, accessToken);
+
+            /// <summary>
+            /// [SYNC] Retrieves subscriber list for a <paramref name="channel"/>.
+            /// <para>Authenticated, required scope: channel_subscriptions</para>
+            /// </summary>
+            /// <param name="channel">The channel to check against.</param>
+            /// <param name="accessToken">An oauth token with the required scope.</param>
+            /// <returns>List of channel subscribers</returns>
+            public static ChannelSubscribersResponse GetChannelSubscribers(string channel, string accessToken = null) => Task.Run(() => Internal.TwitchApi.GetAllChannelSubscribers(channel, accessToken)).Result;
+            /// <summary>
+            /// [ASYNC] Retrieves subscriber list for a <paramref name="channel"/>.
+            /// <para>Authenticated, required scope: channel_subscriptions</para>
+            /// </summary>
+            /// <param name="channel">The channel to check against.</param>
+            /// <param name="accessToken">An oauth token with the required scope.</param>
+            /// <returns>List of channel subscribers</returns>
+            public static async Task<ChannelSubscribersResponse> GetChannelSubscribersAsync(string channel, string accessToken = null) => await Internal.TwitchApi.GetAllChannelSubscribers(channel, accessToken);
         }
 
         /// <summary>

--- a/TwitchLib/TwitchLib.csproj
+++ b/TwitchLib/TwitchLib.csproj
@@ -141,6 +141,7 @@
     <Compile Include="Models\API\Block.cs" />
     <Compile Include="Models\API\ChannelHasUserSubscribedResponse.cs" />
     <Compile Include="Models\API\Channels.cs" />
+    <Compile Include="Models\API\ChannelSubscribersResponse.cs" />
     <Compile Include="Models\API\FeaturedStream.cs" />
     <Compile Include="Models\API\FeedResponse.cs" />
     <Compile Include="Models\API\Game.cs" />
@@ -148,6 +149,7 @@
     <Compile Include="Models\API\Post.cs" />
     <Compile Include="Models\API\PostToChannelFeedResponse.cs" />
     <Compile Include="Models\API\StreamsSummary.cs" />
+    <Compile Include="Models\API\Subscription.cs" />
     <Compile Include="Models\API\User.cs" />
     <Compile Include="Models\API\BadgeResponse.cs" />
     <Compile Include="Models\Client\ChannelState.cs" />


### PR DESCRIPTION
I noticed yesterday that the project has been restructured considerably since I initially checked this months ago. 
Looking great now, well done =)

I made the decision to ditch my library and switch to this tonight for my Streamers bot, however during implementation I noticed a method I needed was missing. The ability to pull a full list of subscribers rather than making multiple API calls to check whether a user was a subscriber or not.

I've added it. Tried to keep it inline with your current restructuring. You may decide to add or may have left out for a reason, but it's here if you decide to merge :)

Returns a Response with List of type User,  and int (Count)