### PR TITLE
Switched to .Net Standard 1.3 compatible Websocket library

### DIFF
--- a/TwitchLib/Internal/WebSocketClient.cs
+++ b/TwitchLib/Internal/WebSocketClient.cs
@@ -1,0 +1,183 @@
+﻿using System;
+using System.Net.WebSockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TwitchLib.Internal
+{
+    public class WebSocketClient
+    {
+        private const int ReceiveChunkSize = 1024;
+        private const int SendChunkSize = 1024;
+
+        public readonly ClientWebSocket Client;
+        private readonly Uri _uri;
+        private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
+        private readonly CancellationToken _cancellationToken;
+
+        public event Action<WebSocketClient> OnConnected;
+        public event Action<WebSocketClient, string> OnMessage;
+        public event Action<WebSocketClient> OnDisconnected;
+        public event Action<WebSocketClient, Exception> OnError;
+
+        protected WebSocketClient(Uri uri)
+        {
+            Client = new ClientWebSocket();
+            Client.Options.KeepAliveInterval = TimeSpan.FromSeconds(20);
+            _uri = uri;
+            _cancellationToken = _cancellationTokenSource.Token;
+        }
+
+        /// <summary>
+        /// Creates a new instance.
+        /// </summary>
+        /// <param name="uri">The URI of the WebSocket server.</param>
+        /// <returns></returns>
+        public static WebSocketClient Create(Uri uri)
+        {
+            return new WebSocketClient(uri);
+        }
+
+        /// <summary>
+        /// Connects to the WebSocket server.
+        /// </summary>
+        /// <returns></returns>
+        public WebSocketClient Connect()
+        {
+            ConnectAsync();
+            return this;
+        }
+
+        /// <summary>
+        /// Connects to the WebSocket server.
+        /// </summary>
+        /// <returns></returns>
+        public void Disconnect()
+        {
+            Client.CloseAsync(WebSocketCloseStatus.NormalClosure, "Normal", CancellationToken.None);
+        }
+        /// <summary>
+        /// Send a message to the WebSocket server.
+        /// </summary>
+        /// <param name="message">The message to send</param>
+        public void SendMessage(string message)
+        {
+            SendMessageAsync(message);
+        }
+
+        private async void SendMessageAsync(string message)
+        {
+            if (Client.State != WebSocketState.Open)
+            {
+                throw new Exception("Connection is not open.");
+            }
+
+            var messageBuffer = Encoding.UTF8.GetBytes(message);
+            var messagesCount = (int)Math.Ceiling((double)messageBuffer.Length / SendChunkSize);
+
+            for (var i = 0; i < messagesCount; i++)
+            {
+                var offset = (SendChunkSize * i);
+                var count = SendChunkSize;
+                var lastMessage = ((i + 1) == messagesCount);
+
+                if ((count * (i + 1)) > messageBuffer.Length)
+                {
+                    count = messageBuffer.Length - offset;
+                }
+
+                await Client.SendAsync(new ArraySegment<byte>(messageBuffer, offset, count), WebSocketMessageType.Text, lastMessage, _cancellationToken);
+            }
+        }
+
+        private async void ConnectAsync()
+        {
+            await Client.ConnectAsync(_uri, _cancellationToken);
+            CallOnConnected();
+            StartListen();
+        }
+
+        private async void StartListen()
+        {
+            var buffer = new byte[ReceiveChunkSize];
+
+            try
+            {
+                while (Client.State == WebSocketState.Open)
+                {
+                    var stringResult = new StringBuilder();
+
+
+                    WebSocketReceiveResult result;
+                    do
+                    {
+                        result = await Client.ReceiveAsync(new ArraySegment<byte>(buffer), _cancellationToken);
+
+                        if (result.MessageType == WebSocketMessageType.Close)
+                        {
+                            await
+                                Client.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None);
+                            CallOnDisconnected();
+                        }
+                        else
+                        {
+                            var str = Encoding.UTF8.GetString(buffer, 0, result.Count);
+                            stringResult.Append(str);
+                        }
+
+                    } while (!result.EndOfMessage);
+
+                    CallOnMessage(stringResult);
+
+                }
+            }
+            catch (Exception e)
+            {
+                CallOnError(e);
+                CallOnDisconnected();
+            }
+            finally
+            {
+                Client.Dispose();
+            }
+        }
+
+        private void CallOnError(Exception e)
+        {
+            if (OnError != null)
+                RunInTask(() => OnError(this, e));
+        }
+
+        private void CallOnMessage(StringBuilder stringResult)
+        {
+            if (OnMessage != null)
+                RunInTask(() => OnMessage(this, stringResult.ToString()));
+        }
+
+        private void CallOnDisconnected()
+        {
+            if (OnDisconnected != null)
+                RunInTask(() => OnDisconnected(this));
+        }
+
+        private void CallOnConnected()
+        {
+            if (OnConnected != null)
+                RunInTask(() => OnConnected(this));
+        }
+
+        private static void RunInTask(Action action)
+        {
+            Task.Factory.StartNew(action);
+        }
+
+        public void Dispose()
+        {
+            if (Client != null)
+            {
+                Client.Dispose();
+            }
+        }
+    }
+}

--- a/TwitchLib/TwitchLib.csproj
+++ b/TwitchLib/TwitchLib.csproj
@@ -9,10 +9,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TwitchLib</RootNamespace>
     <AssemblyName>TwitchLib</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -45,19 +46,40 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.WebSockets, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.WebSockets.4.3.0\lib\net46\System.Net.WebSockets.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Net.WebSockets.Client, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.WebSockets.Client.4.3.0\lib\net46\System.Net.WebSockets.Client.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Algorithms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net46\System.Security.Cryptography.Algorithms.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net46\System.Security.Cryptography.X509Certificates.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="WebSocket4Net, Version=0.14.1.0, Culture=neutral, PublicKeyToken=eb4e154b696bf72a, processorArchitecture=MSIL">
-      <HintPath>..\packages\WebSocket4Net.0.14.1\lib\net45\WebSocket4Net.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Events\Client\OnBeingHostedArgs.cs" />
     <Compile Include="Exceptions\Client\BadListenException.cs" />
+    <Compile Include="Internal\WebSocketClient.cs" />
     <Compile Include="Models\API\v5\User.cs" />
     <Compile Include="Common\Helpers.cs" />
     <Compile Include="Common\Logging.cs" />

--- a/TwitchLib/packages.config
+++ b/TwitchLib/packages.config
@@ -1,5 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
+  <package id="System.Net.WebSockets" version="4.3.0" targetFramework="net46" />
+  <package id="System.Net.WebSockets.Client" version="4.3.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net46" />
   <package id="WebSocket4Net" version="0.14.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Feel free to clean it up a bit, I put it together on a train :P
May need a bit more testing.

It's a start at making TwitchLib .Net Core compatible, as System.Net.Websockets.Client is .Net Standard 1.3 and Mono compatible.

Maybe we can look at Meebey next, and get an internal IrcClient written.

**WARNING: it does change the target client profile to .Net 4.6**