### PR TITLE
Small bug fix for null in TwitchClient constructor for null channel parameter

### DIFF
--- a/TwitchLib/TwitchClient.cs
+++ b/TwitchLib/TwitchClient.cs
@@ -239,7 +239,7 @@ namespace TwitchLib
                 Common.Logging.Log($"TwitchLib-TwitchClient initialized, assembly version: {System.Reflection.Assembly.GetExecutingAssembly().GetName().Version}");
             _credentials = credentials;
             TwitchUsername = _credentials.TwitchUsername;
-            _autoJoinChannel = channel.ToLower();
+            _autoJoinChannel = channel?.ToLower();
             if(chatCommandIdentifier != '\0')
                 _chatCommandIdentifiers.Add(chatCommandIdentifier);
             if (whisperCommandIdentifier != '\0')


### PR DESCRIPTION
Hey, I've made small change to the code that fixes issue when there is no channel parameter provided in constructor of TwitchClient class.