### PR TITLE
Fix validation clientid

### DIFF
--- a/TwitchLib/Internal/TwitchAPI.cs
+++ b/TwitchLib/Internal/TwitchAPI.cs
@@ -853,7 +853,7 @@ namespace TwitchLib.Internal
 
         internal static async Task<bool> ValidClientId(string clientId, bool updateClientIdOnSuccess = true)
         {
-            string oldClientId;
+            string oldClientId = String.Empty;
             if (!string.IsNullOrEmpty(ClientId))
                 oldClientId = ClientId;
 			
@@ -863,7 +863,7 @@ namespace TwitchLib.Internal
             if (json.SelectToken("identified") != null && (bool)json.SelectToken("identified") == true)
                 return true;
 			else {
-                ClientId = String.Empty;
+                ClientId = oldClientId;
                 return false;
             }
         }

--- a/TwitchLib/Internal/TwitchAPI.cs
+++ b/TwitchLib/Internal/TwitchAPI.cs
@@ -856,11 +856,16 @@ namespace TwitchLib.Internal
             string oldClientId;
             if (!string.IsNullOrEmpty(ClientId))
                 oldClientId = ClientId;
+			
+			ClientId = clientId;
             var resp = await Requests.MakeGetRequest("https://api.twitch.tv/kraken");
             var json = JObject.Parse(resp);
             if (json.SelectToken("identified") != null && (bool)json.SelectToken("identified") == true)
                 return true;
-            return false;
+			else {
+                ClientId = String.Empty;
+                return false;
+            }
         }
 
         private static async void ValidClientId()


### PR DESCRIPTION
Hey,

i think i found a bug in this functions.
if you call the function direct (not over the method "SetClientId"), no client id is specified.

Maybe you know a better way to solve it?


Problem:
I want to check my clientid.
Your method "MakeGetRequest" checks for clientid or oauthkey and when both are not provided, your lib throws an exception.
You have to set the ClientID first and then make the request.