### PR TITLE
Bit Events and Listen

### DIFF
--- a/TwitchLib/Models/PubSub/Responses/Message.cs
+++ b/TwitchLib/Models/PubSub/Responses/Message.cs
@@ -24,7 +24,7 @@
                 case "chat_moderator_actions":
                     messageData = new ChatModeratorActions(encodedJsonMessage);
                     break;
-                case "channel-bitsevents":
+                case "channel-bits-events-v1":
                     messageData = new ChannelBitsEvents(encodedJsonMessage);
                     break;
                 case "video-playback":

--- a/TwitchLib/Models/PubSub/Responses/Messages/ChannelBitsEvents.cs
+++ b/TwitchLib/Models/PubSub/Responses/Messages/ChannelBitsEvents.cs
@@ -24,26 +24,11 @@
         public int TotalBitsUsed { get; protected set; }
         /// <summary>Context related to event.</summary>
         public string Context { get; protected set; }
-        /// <summary>Next badge at value</summary>
-        public int NewBadgeEntitlement { get; protected set; }
-        /// <summary>Previous badge received at value</summary>
-        public int PreviousBadgeEntitlement { get; protected set; }
 
         /// <summary>ChannelBitsEvent model constructor.</summary>
         public ChannelBitsEvents(string jsonStr)
         {
-
-
-            /*
-                    JObject message = JObject.Parse((String)json["data"]["message"]);
-
-                    String username = (String)message["data"]["user_name"];
-                    String chat_message = (String)message["data"]["chat_message"];
-                    int bits = (Int32)message["data"]["bits_used"];
-
-                    // Then, if bits > bitsThreshold, create an event.
-                    String displayMessage = String.Format("{0} donated {1} bits.", username, bits);
-             */
+            string _local = jsonStr;
 
             JToken json = JObject.Parse(jsonStr);
             Username = json.SelectToken("data").SelectToken("user_name")?.ToString();
@@ -55,8 +40,6 @@
             BitsUsed = int.Parse(json.SelectToken("data").SelectToken("bits_used").ToString());
             TotalBitsUsed = int.Parse(json.SelectToken("data").SelectToken("total_bits_used").ToString());
             Context = json.SelectToken("data").SelectToken("context")?.ToString();
-            NewBadgeEntitlement = int.Parse(json.SelectToken("data").SelectToken("badge_entitlement").SelectToken("new_version").ToString());
-            PreviousBadgeEntitlement = int.Parse(json.SelectToken("data").SelectToken("badge_entitlement").SelectToken("previous_version").ToString());
         }
     }
 }

--- a/TwitchLib/Models/PubSub/Responses/Messages/ChannelBitsEvents.cs
+++ b/TwitchLib/Models/PubSub/Responses/Messages/ChannelBitsEvents.cs
@@ -24,20 +24,39 @@
         public int TotalBitsUsed { get; protected set; }
         /// <summary>Context related to event.</summary>
         public string Context { get; protected set; }
+        /// <summary>Next badge at value</summary>
+        public int NewBadgeEntitlement { get; protected set; }
+        /// <summary>Previous badge received at value</summary>
+        public int PreviousBadgeEntitlement { get; protected set; }
 
         /// <summary>ChannelBitsEvent model constructor.</summary>
         public ChannelBitsEvents(string jsonStr)
         {
+
+
+            /*
+                    JObject message = JObject.Parse((String)json["data"]["message"]);
+
+                    String username = (String)message["data"]["user_name"];
+                    String chat_message = (String)message["data"]["chat_message"];
+                    int bits = (Int32)message["data"]["bits_used"];
+
+                    // Then, if bits > bitsThreshold, create an event.
+                    String displayMessage = String.Format("{0} donated {1} bits.", username, bits);
+             */
+
             JToken json = JObject.Parse(jsonStr);
-            Username = json.SelectToken("user_name")?.ToString();
-            ChannelName = json.SelectToken("channel_name")?.ToString();
-            UserId = json.SelectToken("user_id")?.ToString();
-            ChannelId = json.SelectToken("channel_id")?.ToString();
-            Time = json.SelectToken("time")?.ToString();
-            ChatMessage = json.SelectToken("chat_message")?.ToString();
-            BitsUsed = int.Parse(json.SelectToken("bits_used").ToString());
-            TotalBitsUsed = int.Parse(json.SelectToken("total_bits_used").ToString());
-            Context = json.SelectToken("context")?.ToString();
+            Username = json.SelectToken("data").SelectToken("user_name")?.ToString();
+            ChannelName = json.SelectToken("data").SelectToken("channel_name")?.ToString();
+            UserId = json.SelectToken("data").SelectToken("user_id")?.ToString();
+            ChannelId = json.SelectToken("data").SelectToken("channel_id")?.ToString();
+            Time = json.SelectToken("data").SelectToken("time")?.ToString();
+            ChatMessage = json.SelectToken("data").SelectToken("chat_message")?.ToString();
+            BitsUsed = int.Parse(json.SelectToken("data").SelectToken("bits_used").ToString());
+            TotalBitsUsed = int.Parse(json.SelectToken("data").SelectToken("total_bits_used").ToString());
+            Context = json.SelectToken("data").SelectToken("context")?.ToString();
+            NewBadgeEntitlement = int.Parse(json.SelectToken("data").SelectToken("badge_entitlement").SelectToken("new_version").ToString());
+            PreviousBadgeEntitlement = int.Parse(json.SelectToken("data").SelectToken("badge_entitlement").SelectToken("previous_version").ToString());
         }
     }
 }


### PR DESCRIPTION
Updating channel-bitsevents to channel-bits-events-v1

Changing how Listen works to compile a list of events to listen to before firing the entire Listen off in one request, because you're going to be specifying the same Oauth key to all of the listen requests anyways.