### PR TITLE
Fix logging initialization, and added missing refs.

### DIFF
--- a/TwitchLib.Testing/Application.API/TwitchLib-API-Tester/Application.API.csproj
+++ b/TwitchLib.Testing/Application.API/TwitchLib-API-Tester/Application.API.csproj
@@ -45,7 +45,7 @@
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="TwitchLib">
-      <HintPath>..\..\TwitchLib\bin\Debug\TwitchLib.dll</HintPath>
+      <HintPath>..\..\..\TwitchLib\bin\Debug\TwitchLib.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/TwitchLib.Testing/Application.ClientAndPubSub/TwitchLib-Client-PubSub-Tester/Application.ClientAndPubSub.csproj
+++ b/TwitchLib.Testing/Application.ClientAndPubSub/TwitchLib-Client-PubSub-Tester/Application.ClientAndPubSub.csproj
@@ -45,7 +45,7 @@
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="TwitchLib">
-      <HintPath>..\..\TwitchLib\bin\Debug\TwitchLib.dll</HintPath>
+      <HintPath>..\..\..\TwitchLib\bin\Debug\TwitchLib.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/TwitchLib/TwitchClient.cs
+++ b/TwitchLib/TwitchClient.cs
@@ -268,11 +268,7 @@
             if (whisperCommandIdentifier != '\0')
                 _whisperCommandIdentifiers.Add(whisperCommandIdentifier);
             Logging = logging;
-            if (Logging)
-            {
-                if (logger == null) Logger = new NullLogFactory().Create("TwitchLibNullLogger");
-                Logger = logger;
-            }
+            Logger = logger ?? new NullLogFactory().Create("TwitchLibNullLogger");
             AutoReListenOnException = autoReListenOnExceptions;
 
             _client = new WebSocket($"ws://{_credentials.TwitchHost}:{_credentials.TwitchPort}");


### PR DESCRIPTION
There was a missing else keyword in logging initialisation. I replaced the if-else statement with a null-coalescing operator. Much cleaner. Added missing refs to the test projects.