### PR TITLE
Inconsistant Parameters in Client events for BotUsername (Breaking)

### DIFF
--- a/TwitchLib/Events/Client/OnConnectedArgs.cs
+++ b/TwitchLib/Events/Client/OnConnectedArgs.cs
@@ -7,7 +7,7 @@
     public class OnConnectedArgs : EventArgs
     {
         /// <summary>Property representing bot username.</summary>
-        public string Username;
+        public string BotUsername;
         /// <summary>Property representing connected channel.</summary>
         public string AutoJoinChannel;
     }

--- a/TwitchLib/Events/Client/OnConnectionErrorArgs.cs
+++ b/TwitchLib/Events/Client/OnConnectionErrorArgs.cs
@@ -10,6 +10,6 @@
         /// <summary></summary>
         public ErrorEvent Error;
         /// <summary>Username of the bot that suffered connection error.</summary>
-        public string Username;
+        public string BotUsername;
     }
 }

--- a/TwitchLib/Events/Client/OnDisconnectedArgs.cs
+++ b/TwitchLib/Events/Client/OnDisconnectedArgs.cs
@@ -7,6 +7,6 @@
     public class OnDisconnectedArgs : EventArgs
     {
         /// <summary>Username of the bot that was disconnected.</summary>
-        public string Username;
+        public string BotUsername;
     }
 }

--- a/TwitchLib/Events/Client/OnJoinedChannelArgs.cs
+++ b/TwitchLib/Events/Client/OnJoinedChannelArgs.cs
@@ -7,7 +7,7 @@
     public class OnJoinedChannelArgs : EventArgs
     {
         /// <summary>Property representing bot username.</summary>
-        public string Username;
+        public string BotUsername;
         /// <summary>Property representing the channel that was joined.</summary>
         public string Channel;
     }


### PR DESCRIPTION
A couple events already had BotUsername.
Changed 4 events from Username > BotUsername
This could be less confusing to anyone using the lib.

This is a breaking change.