### PR TITLE
Fix V3022 warnings from PVS-Studio Static Analyzer

### DIFF
--- a/TwitchLib/Models/Client/ChatCommand.cs
+++ b/TwitchLib/Models/Client/ChatCommand.cs
@@ -25,7 +25,7 @@
         {
             ChatMessage = chatMessage;
             CommandText = chatMessage.Message.Split(' ')?[0].Substring(1, chatMessage.Message.Split(' ')[0].Length - 1) ?? chatMessage.Message.Substring(1, chatMessage.Message.Length - 1);
-            ArgumentsAsString = chatMessage.Message.Contains(" ") ? chatMessage.Message.Replace(chatMessage.Message.Split(' ')?[0] + " ", "") ?? "" : "";
+            ArgumentsAsString = chatMessage.Message.Contains(" ") ? chatMessage.Message.Replace(chatMessage.Message.Split(' ')?[0] + " ", "") : "";
             if (!chatMessage.Message.Contains("\"") || chatMessage.Message.Count(x => x == '"') % 2 == 1)
                 ArgumentsAsList = chatMessage.Message.Split(' ')?.Where(arg => arg != chatMessage.Message[0] + CommandText).ToList<string>() ?? new List<string>();
             else

--- a/TwitchLib/TwitchClient.cs
+++ b/TwitchLib/TwitchClient.cs
@@ -898,7 +898,7 @@
                     var whisperMessage = new WhisperMessage(ircMessage, _credentials.TwitchUsername);
                     string command = whisperMessage.Message.Split(' ')?[0].Substring(1, whisperMessage.Message.Split(' ')[0].Length - 1) ?? whisperMessage.Message.Substring(1, whisperMessage.Message.Length - 1);
                     var argumentsAsList = whisperMessage.Message.Split(' ')?.Where(arg => arg != whisperMessage.Message[0] + command).ToList<string>() ?? new List<string>();
-                    string argumentsAsString = whisperMessage.Message.Replace(whisperMessage.Message.Split(' ')?[0] + " ", "") ?? "";
+                    string argumentsAsString = whisperMessage.Message.Replace(whisperMessage.Message.Split(' ')?[0] + " ", "");
                     OnWhisperCommandReceived?.Invoke(this, new OnWhisperCommandReceivedArgs { Command = command, WhisperMessage = whisperMessage, ArgumentsAsList = argumentsAsList, ArgumentsAsString = argumentsAsString });
                     return;
                 }


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug found using PVS-Studio. Warnings:

[V3022](https://www.viva64.com/en/w/v3022/) Expression 'chatMessage.Message.Replace(chatMessage.Message.Split(' ')?[0] + " ", "")' is always not null. The operator '??' is excessive. ChatCommand.cs 28
[V3022](https://www.viva64.com/en/w/v3022/) Expression 'whisperMessage.Message.Replace(whisperMessage.Message.Split(' ')?[0] + " ", "")' is always not null. The operator '??' is excessive. TwitchClient.cs 901