### PR TITLE
Fix V3031 warnings from PVS-Studio Static Analyzer

### DIFF
--- a/TwitchLib/Services/LiveStreamMonitor.cs
+++ b/TwitchLib/Services/LiveStreamMonitor.cs
@@ -158,7 +158,7 @@
                         //have gone offline
                         _statuses[channel] = null;
 
-                        if (!_isStartup || (_isStartup && _invokeEventsOnStart))
+                        if (!_isStartup || _invokeEventsOnStart)
                         {
                             OnStreamOffline?.Invoke(this,
                                 new OnStreamOfflineArgs { ChannelId = channel, Channel = channelName, CheckIntervalSeconds = CheckIntervalSeconds });
@@ -172,7 +172,7 @@
                     if (_statuses[channel] == null)
                     {
                         //have gone online
-                        if (!_isStartup || (_isStartup && _invokeEventsOnStart))
+                        if (!_isStartup || _invokeEventsOnStart)
                         {
                             OnStreamOnline?.Invoke(this,
                                 new OnStreamOnlineArgs { ChannelId = channel, Channel = channelName, Stream = currentStream, CheckIntervalSeconds = CheckIntervalSeconds });
@@ -181,7 +181,7 @@
                     else
                     {
                         //stream updated
-                        if (!_isStartup || (_isStartup && _invokeEventsOnStart))
+                        if (!_isStartup || _invokeEventsOnStart)
                         {
                             OnStreamUpdate?.Invoke(this,
                                 new OnStreamUpdateArgs { ChannelId = channel, Channel = channelName, Stream = currentStream, CheckIntervalSeconds = CheckIntervalSeconds });


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug found using PVS-Studio. Warnings:

[V3031](https://www.viva64.com/en/w/v3031/) An excessive check can be simplified. The '||' operator is surrounded by opposite expressions '!_isStartup' and '_isStartup'. LiveStreamMonitor.cs 161
[V3031](https://www.viva64.com/en/w/v3031/) An excessive check can be simplified. The '||' operator is surrounded by opposite expressions '!_isStartup' and '_isStartup'. LiveStreamMonitor.cs 175
[V3031](https://www.viva64.com/en/w/v3031/) An excessive check can be simplified. The '||' operator is surrounded by opposite expressions '!_isStartup' and '_isStartup'. LiveStreamMonitor.cs 184