### PR TITLE
Setting title with a "\" fails, this escapes that character

### DIFF
--- a/TwitchLib/Api/Sections/Channels.cs
+++ b/TwitchLib/Api/Sections/Channels.cs
@@ -177,7 +177,10 @@
                 if (string.IsNullOrWhiteSpace(channelId)) { throw new Exceptions.API.BadParameterException("The channel id is not valid. It is not allowed to be null, empty or filled with whitespaces."); }
                 List<KeyValuePair<string, string>> datas = new List<KeyValuePair<string, string>>();
                 if (!string.IsNullOrEmpty(status))
+                {
+                    status = status.Replace("\\", "\\\\");
                     datas.Add(new KeyValuePair<string, string>("status", "\"" + status + "\""));
+                }
                 if (!string.IsNullOrEmpty(game))
                     datas.Add(new KeyValuePair<string, string>("game", "\"" + game + "\""));
                 if (!string.IsNullOrEmpty(delay))


### PR DESCRIPTION
Problem: If you submit a title with a "\" character, the request fails with an exception.

Fix: Escape "\" by changing it to "\\"

Applied to: I only added this change to changing the channel's title.  There may be other fields that warrant a similar solution, and there may be other characters that need escaping.