### PR TITLE
API ExpiredTokenException and Refresh Token Method for the API

### DIFF
--- a/TwitchLib/Api/Sections/Auth.cs
+++ b/TwitchLib/Api/Sections/Auth.cs
@@ -23,7 +23,7 @@
             }
 
             #region GetFreshToken
-            public async Task<Models.API.v5.Auth.RefreshResponse> RefreshAuthToken(string refreshToken, string clientSecret, string clientId = null)
+            public async Task<Models.API.v5.Auth.RefreshResponse> RefreshAuthTokenAsync(string refreshToken, string clientSecret, string clientId = null)
             {
                 var internalClientId = clientId ?? Api.Settings.ClientId;
 

--- a/TwitchLib/Api/Sections/Auth.cs
+++ b/TwitchLib/Api/Sections/Auth.cs
@@ -23,6 +23,12 @@
             }
 
             #region GetFreshToken
+            /// <summary>
+            /// <para>[ASYNC] Refreshes an expired auth token</para>
+            /// <para>ATTENTION: Client Secret required. Never expose it to consumers!</para>
+            /// <para>Throws a BadRequest Exception if the request fails due to a bad refresh token</para>
+            /// </summary>
+            /// <returns>A RefreshResponse object that holds your new auth and refresh token and the list of scopes for that token</returns>
             public async Task<Models.API.v5.Auth.RefreshResponse> RefreshAuthTokenAsync(string refreshToken, string clientSecret, string clientId = null)
             {
                 var internalClientId = clientId ?? Api.Settings.ClientId;

--- a/TwitchLib/Api/Sections/Auth.cs
+++ b/TwitchLib/Api/Sections/Auth.cs
@@ -1,0 +1,43 @@
+﻿namespace TwitchLib
+{
+    using System.Collections.Generic;
+    #region using directives
+    using System.Threading.Tasks;
+    using TwitchLib.Api;
+    using TwitchLib.Enums;
+    #endregion
+
+    public class Auth
+    {
+        public V5 v5 { get; }
+
+        public Auth(TwitchAPI api)
+        {
+            v5 = new V5(api);
+        }
+
+        public class V5 : ApiSection
+        {
+            public V5(TwitchAPI api) : base(api)
+            {
+            }
+
+            #region GetFreshToken
+            public async Task<Models.API.v5.Auth.RefreshResponse> RefreshAuthToken(string refreshToken, string clientSecret, string clientId = null)
+            {
+                if (string.IsNullOrWhiteSpace(refreshToken)) { throw new Exceptions.API.BadParameterException("The refresh token is not valid. It is not allowed to be null, empty or filled with whitespaces."); }
+                if (string.IsNullOrWhiteSpace(clientSecret)) { throw new Exceptions.API.BadParameterException("The clientSecret is not valid. It is not allowed to be null, empty or filled with whitespaces."); }
+                var getParams = new List<KeyValuePair<string, string>>
+                {
+                    new KeyValuePair<string, string> ("grant_type", "refresh_token"),
+                    new KeyValuePair<string, string> ("refresh_token", refreshToken),
+                    new KeyValuePair<string, string> ("client_id", clientId),
+                    new KeyValuePair<string, string> ("client_secret", clientSecret)
+                };
+
+                return await Api.PostGenericAsync<Models.API.v5.Auth.RefreshResponse>("https://api.twitch.tv/kraken/oauth2/token", null, getParams);            
+            }
+            #endregion
+        }
+    }
+}

--- a/TwitchLib/Api/Sections/Auth.cs
+++ b/TwitchLib/Api/Sections/Auth.cs
@@ -1,10 +1,10 @@
 ﻿namespace TwitchLib
 {
-    using System.Collections.Generic;
+
     #region using directives
     using System.Threading.Tasks;
-    using TwitchLib.Api;
-    using TwitchLib.Enums;
+    using Api;
+    using System.Collections.Generic;
     #endregion
 
     public class Auth
@@ -25,8 +25,12 @@
             #region GetFreshToken
             public async Task<Models.API.v5.Auth.RefreshResponse> RefreshAuthToken(string refreshToken, string clientSecret, string clientId = null)
             {
+                var internalClientId = clientId ?? Api.Settings.ClientId;
+
                 if (string.IsNullOrWhiteSpace(refreshToken)) { throw new Exceptions.API.BadParameterException("The refresh token is not valid. It is not allowed to be null, empty or filled with whitespaces."); }
-                if (string.IsNullOrWhiteSpace(clientSecret)) { throw new Exceptions.API.BadParameterException("The clientSecret is not valid. It is not allowed to be null, empty or filled with whitespaces."); }
+                if (string.IsNullOrWhiteSpace(clientSecret)) { throw new Exceptions.API.BadParameterException("The client secret is not valid. It is not allowed to be null, empty or filled with whitespaces."); }
+                if (string.IsNullOrWhiteSpace(internalClientId)) { throw new Exceptions.API.BadParameterException("The clientId is not valid. It is not allowed to be null, empty or filled with whitespaces."); }
+
                 var getParams = new List<KeyValuePair<string, string>>
                 {
                     new KeyValuePair<string, string> ("grant_type", "refresh_token"),

--- a/TwitchLib/Api/Sections/Auth.cs
+++ b/TwitchLib/Api/Sections/Auth.cs
@@ -41,7 +41,7 @@
                 {
                     new KeyValuePair<string, string> ("grant_type", "refresh_token"),
                     new KeyValuePair<string, string> ("refresh_token", refreshToken),
-                    new KeyValuePair<string, string> ("client_id", clientId),
+                    new KeyValuePair<string, string> ("client_id", internalClientId),
                     new KeyValuePair<string, string> ("client_secret", clientSecret)
                 };
 

--- a/TwitchLib/Api/TwitchAPI.cs
+++ b/TwitchLib/Api/TwitchAPI.cs
@@ -20,6 +20,7 @@ namespace TwitchLib
     {
         private readonly TwitchLibJsonSerializer jsonSerializer;
         public IApiSettings Settings { get; }
+        public Auth Auth { get; }
         public Blocks Blocks { get; }
         public Badges Badges { get; }
         public Bits Bits { get; }
@@ -46,6 +47,7 @@ namespace TwitchLib
 
         public TwitchAPI(string clientId = null, string accessToken = null)
         {
+            Auth = new Auth(this);
             Blocks = new Blocks(this);
             Badges = new Badges(this);
             Bits = new Bits(this);
@@ -361,7 +363,7 @@ namespace TwitchLib
             switch (errorResp.StatusCode)
             {
                 case HttpStatusCode.BadRequest:
-                    throw new BadRequestException("Your request failed because either: \n 1. Your ClientID was invalid/not set.\n 2. You requested a username when the server was expecting a user ID.");
+                    throw new BadRequestException("Your request failed because either: \n 1. Your ClientID was invalid/not set. \n 2. Your refresh token was invalid. \n 3. You requested a username when the server was expecting a user ID.");
                 case HttpStatusCode.Unauthorized:
                     var authenticateHeader = errorResp.Headers.GetValue("WWW-Authenticate");
                     if(string.IsNullOrEmpty(authenticateHeader))

--- a/TwitchLib/Api/TwitchAPI.cs
+++ b/TwitchLib/Api/TwitchAPI.cs
@@ -1,17 +1,19 @@
+
+
 namespace TwitchLib
 {
+    #region using directives
     using Newtonsoft.Json;
     using Newtonsoft.Json.Serialization;
-
-    #region using directives
+    using SuperSocket.ClientEngine;
     using System;
     using System.Collections.Generic;
     using System.IO;
     using System.Net;
     using System.Threading.Tasks;
-    using TwitchLib.Api.Sections;
-    using TwitchLib.Enums;
-    using TwitchLib.Exceptions.API;
+    using Api.Sections;
+    using Enums;
+    using Exceptions.API;
     #endregion
 
     public class TwitchAPI : ITwitchAPI
@@ -322,7 +324,7 @@ namespace TwitchLib
                 }
             }
 
-            var req = (HttpWebRequest)HttpWebRequest.Create(url);
+            var req = (HttpWebRequest)WebRequest.Create(url);
             req.Method = requestType;
             var response = (HttpWebResponse)req.GetResponse();
             return (int)response.StatusCode;
@@ -353,15 +355,22 @@ namespace TwitchLib
         #region handleWebException
         private void handleWebException(WebException e)
         {
-            HttpWebResponse errorResp = e.Response as HttpWebResponse;
-            if (errorResp == null)
+            if (!(e.Response is HttpWebResponse errorResp))
                 throw e;
+
             switch (errorResp.StatusCode)
             {
                 case HttpStatusCode.BadRequest:
                     throw new BadRequestException("Your request failed because either: \n 1. Your ClientID was invalid/not set.\n 2. You requested a username when the server was expecting a user ID.");
                 case HttpStatusCode.Unauthorized:
-                    throw new BadScopeException("Your request was blocked due to bad credentials (do you have the right scope for your access token?).");
+                    var authenticateHeader = errorResp.Headers.GetValue("WWW-Authenticate");
+                    if(string.IsNullOrEmpty(authenticateHeader))
+                        throw new BadScopeException("Your request was blocked due to bad credentials (do you have the right scope for your access token?).");
+
+                    var invalidTokenFound = authenticateHeader.Contains("error='invalid_token'");
+                    if(invalidTokenFound)
+                        throw new TokenExpiredException("Your request was blocked du to an expired Token. Please refresh your token and update your API instance settings.");
+                    break;
                 case HttpStatusCode.NotFound:
                     throw new BadResourceException("The resource you tried to access was not valid.");
                 case (HttpStatusCode)422:

--- a/TwitchLib/Exceptions/API/TokenExpiredException.cs
+++ b/TwitchLib/Exceptions/API/TokenExpiredException.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace TwitchLib.Exceptions.API
+{
+    #region using directives
+    using System;
+    #endregion
+    /// <summary>Exception representing a detection that the OAuth token expired</summary>
+    public class TokenExpiredException : Exception
+    {
+        /// <summary>Exception constructor</summary>
+        public TokenExpiredException(string data)
+            : base(data)
+        {
+        }
+    }
+}

--- a/TwitchLib/Models/API/v5/Auth/RefreshResponse.cs
+++ b/TwitchLib/Models/API/v5/Auth/RefreshResponse.cs
@@ -1,0 +1,17 @@
+﻿
+using Newtonsoft.Json;
+
+namespace TwitchLib.Models.API.v5.Auth
+{
+    public class RefreshResponse
+    {
+        [JsonProperty(PropertyName = "access_token")]
+        public string AccessToken { get; protected set; }
+
+        [JsonProperty(PropertyName = "refresh_token")]
+        public string RefreshToken { get; protected set; }
+
+        [JsonProperty(PropertyName = "scope")]
+        public string[] Scopes { get; protected set; }
+    }
+}


### PR DESCRIPTION
Hey swiffty!

I put sth together that catches an expired token response and throws an exception.
It worked quite well for me until now.

But bcs this is hard to test and maybe not the cleanest way I would say we put this for discussion for 1-2 days so ppl can review it and maybe make some own tests and throw in some improvement thoufhts? Your decision.

Regards

Syzuna

PS: For catching IRC login fails due to an expired token you can use the InvalidLogin event from the client! Bcs Twitch just throws this for an invalid token while logging into the IRC server