### PR TITLE
Fixed problem where starting LiveStreamMonitor might happen before service returned from TwitchAPI getting UserIds

### DIFF
--- a/TwitchLib/Services/LiveStreamMonitor.cs
+++ b/TwitchLib/Services/LiveStreamMonitor.cs
@@ -120,7 +120,7 @@ namespace TwitchLib.Services
         /// <param name="usernames">List of channels to monitor as usernames</param>
         public void SetStreamsByUsername(List<string> usernames)
         {
-            _getUserIds(usernames);
+            _getUserIds(usernames).Wait();
 
             foreach (var item in _channelToId.Keys.Where(x => !usernames.Any(channelToId => channelToId.Equals(x))).ToList())
                 _channelToId.TryRemove(item, out string _);
@@ -217,7 +217,7 @@ namespace TwitchLib.Services
             return livestreamers;
         }
 
-        private async void _getUserIds(List<string> usernames)
+        private async Task _getUserIds(List<string> usernames)
         {
             var usernamesToGet = usernames.Where(u => !_channelToId.Any(c => c.Key.Equals(u))).ToList();
             var pages = (usernamesToGet.Count + 100 - 1) / 100;


### PR DESCRIPTION
Added return type Task on _getUserIds() instead of void
Added _getUserIds.Wait() so function doesn't return asynchronously