### PR TITLE
Issue 347

### DIFF
--- a/TwitchLib/Models/API/Helix/Videos/GetVideos/GetVideosResponse.cs
+++ b/TwitchLib/Models/API/Helix/Videos/GetVideos/GetVideosResponse.cs
@@ -1,7 +1,5 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Text;
+using TwitchLib.Models.API.Helix.Common;
 
 namespace TwitchLib.Models.API.Helix.Videos.GetVideos
 {
@@ -9,5 +7,7 @@ namespace TwitchLib.Models.API.Helix.Videos.GetVideos
     {
         [JsonProperty(PropertyName = "data")]
         public Video[] Videos { get; protected set; }
+        [JsonProperty(PropertyName = "pagination")]
+        public Pagination Pagination { get; protected set; }
     }
 }

--- a/TwitchLib/Models/API/Helix/Videos/GetVideos/Video.cs
+++ b/TwitchLib/Models/API/Helix/Videos/GetVideos/Video.cs
@@ -1,7 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace TwitchLib.Models.API.Helix.Videos.GetVideos
 {
@@ -11,6 +8,8 @@ namespace TwitchLib.Models.API.Helix.Videos.GetVideos
         public string CreatedAt { get; protected set; }
         [JsonProperty(PropertyName = "description")]
         public string Description { get; protected set; }
+        [JsonProperty(PropertyName = "duration")]
+        public string Duration { get; protected set; }
         [JsonProperty(PropertyName = "id")]
         public string Id { get; protected set; }
         [JsonProperty(PropertyName = "language")]


### PR DESCRIPTION
This will address https://github.com/swiftyspiffy/TwitchLib/issues/347 by adding pagination to the Helix API GET videos response. I also added the `duration` property, which is documented at https://dev.twitch.tv/docs/api/reference#get-videos, but is missing from the model as well.