### PR TITLE
Added Fixed Not Exisiting Channel Check back

### DIFF
--- a/TwitchLib/Events/Client/OnFailureToReceiveJoinConfirmationArgs.cs
+++ b/TwitchLib/Events/Client/OnFailureToReceiveJoinConfirmationArgs.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using TwitchLib.Exceptions.Client;
+
+namespace TwitchLib.Events.Client
+{
+    public class OnFailureToReceiveJoinConfirmationArgs : EventArgs
+    {
+        public FailureToReceiveJoinConfirmationException Exception;
+    }
+}

--- a/TwitchLib/Exceptions/Client/FailureToReceiveJoinConfirmationException.cs
+++ b/TwitchLib/Exceptions/Client/FailureToReceiveJoinConfirmationException.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.Exceptions.Client
+{
+    public class FailureToReceiveJoinConfirmationException
+    {
+        /// <summary>Exception representing failure of client to receive JOIN confirmation.</summary>
+        public string Channel { get; protected set; }
+        /// <summary>Exception construtor.</summary>
+        public FailureToReceiveJoinConfirmationException(string channel)
+        {
+            Channel = channel;
+        }
+    }
+}

--- a/TwitchLib/TwitchClient.cs
+++ b/TwitchLib/TwitchClient.cs
@@ -269,6 +269,9 @@
 
         /// <summary>Fires when a ritual for a new chatter is received.</summary>
         public EventHandler<OnRitualNewChatterArgs> OnRitualNewChatter;
+        
+        /// <summary>Fires when the client was unable to join a channel.</summary>
+        public EventHandler<OnFailureToReceiveJoinConfirmationArgs> OnFailureToReceiveJoinConfirmation;
 
         /// <summary>Fires when data is received from Twitch that is not able to be parsed.</summary>
         public EventHandler<OnUnaccountedForArgs> OnUnaccountedFor;


### PR DESCRIPTION
Stuff was added twitce to the JoinedChannels List and the awaiting joins list ran empty at some point and produced a null entry in the JoinedChannels list that then caused a Null Ref Exception while iterating

This should be fixed with this.

Would like you to run a test too tho just to be sure.